### PR TITLE
Добавлена проверка битых тегов

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Spellchecking
+name: Checks
 on:
   push:
     branches:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   spellchecking:
-    name: Checking
+    name: Spellchecking
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -15,3 +15,9 @@ jobs:
         submodules: recursive
     - run: npm install yaspeller
     - run: git show -m --name-only -1 --format="format:" | grep --color=never -i '.md' | xargs node_modules/.bin/yaspeller -c common-configs/.yaspellerrc
+  gitlocalize-bug-checking:
+    name: Checking Gitlocalize bugs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: rust-lang-ru/simpleinfra/gitocalize-bug-checker@master


### PR DESCRIPTION
У Gitlocalize новая бага: временами он не преобразовывает свои теги в markdown-сущности, т.е. `{code0}/* ... */{/code0}` не преобразовывается в <code>\`/* ... */\`</code> и подобное. Добавлена проверка таких участков.

Возможны ложные срабатывания