### PR TITLE
remove "links"

### DIFF
--- a/rust-cookbook-ru/src/links.md
+++ b/rust-cookbook-ru/src/links.md
@@ -1,4 +1,3 @@
-Ссылки
 <!--
 Links, in a few categories. Follow the existing structure.
 Keep lines sorted.


### PR DESCRIPTION
Сейчас оно выглядит так:
<img width="775" alt="Снимок экрана 2020-01-09 в 21 25 13" src="https://user-images.githubusercontent.com/4323287/72090494-18603500-3306-11ea-9f98-91bb785dc5aa.png">

Да и у нас автоматическое обновление оригинала удалило из оригинала всё лишнее.

Как рассматривать 0% в гитлокалайзе - хз, думаю лучше было бы, если бы они давали возможность указать, что этот файл нужно просто скопировать из оригинала.